### PR TITLE
fix: [TL-29] isPlaying is set to true after set an empty playlist.

### DIFF
--- a/Video2Audio/Model/AudioPlayer.swift
+++ b/Video2Audio/Model/AudioPlayer.swift
@@ -36,20 +36,21 @@ class AudioPlayer: NSObject {
         isPlaying = false
     }
 
-    func loadAudioFile(at index: Int) throws {
+    func loadAudioFile(at index: Int) -> Bool {
         guard index >= 0 && index < playlist.count else {
             print("No audio to play")
-            return
+            return false
         }
         let url = playlist[index].url
         do {
             player = try AVAudioPlayer(contentsOf: url)
             player?.delegate = self
             player?.prepareToPlay()
+            return true
         } catch {
             print("Error loading audio file: \(error)")
             self.error = error
-            throw error
+            return false
         }
     }
 
@@ -68,7 +69,7 @@ class AudioPlayer: NSObject {
             player.play()
             isPlaying = true
         } else {
-            if let _ = try? loadAudioFile(at: currentIndex) {
+            if loadAudioFile(at: currentIndex) {
                 player?.play()
                 isPlaying = true
             }

--- a/Video2AudioTests/AudioPlayerTests.swift
+++ b/Video2AudioTests/AudioPlayerTests.swift
@@ -31,29 +31,39 @@ final class AudioPlayerSingleAudioTests: XCTestCase {
         XCTAssert(audioPlayer.loopingStatus == .none)
         XCTAssert(audioPlayer.player == nil)
     }
-    // MARK: - invalid audio
+    // MARK: - set audios and play. The playlist auto starts playing after the playlist is set.
+    /// When the playlist is set with invalid audios
     func testPlayInvalidAudio() {
         audioPlayer.setAudios(AudioItem.sampleData)
         XCTAssert(audioPlayer.isPlaying == false, "Playing an invalid audio should not change the isPlaying to true")
         XCTAssert(audioPlayer.player == nil, "Playing an invalid audio should not create the player instance")
+        XCTAssert(audioPlayer.currentIndex == 0, "Playing an invalid audio should not change the currentIndex")
+        XCTAssert(audioPlayer.error != nil, "Playing an in valid audio should set error")
     }
-    // MARK: - play
-    // Play
-    func testPlayingValidAudio() {
+    
+    /// When the playlist is set with valid audios
+    func testPlayValidAudio() {
         audioPlayer.setAudios([audioItem1])
         XCTAssert(audioPlayer.isPlaying == true, "Playing an audio should change the isPlaying to true")
         XCTAssert(audioPlayer.player != nil, "Playing an audio should create the player instance")
     }
+    /// When the playlist is empty
+    func testPlayEmptyList() {
+        audioPlayer.setAudios([])
+        XCTAssert(audioPlayer.isPlaying == false, "Playing an invalid audio should not change the isPlaying to true")
+        XCTAssert(audioPlayer.player == nil, "Playing an invalid audio should not create the player instance")
+        XCTAssert(audioPlayer.currentIndex == 0, "Playing an invalid audio should not change the currentIndex")
+        XCTAssert(audioPlayer.error == nil, "Playing an empty list should not produce errors")
+    }
     
     // MARK: - looping
-    // Looping:none
+    // Single audio in playlist, with looping set to none
     func testLoopingNone() async {
         let duration = try! await AVURLAsset(url: audioItem1.url).load(.duration)
         audioPlayer.setAudios([audioItem1])
         audioPlayer.player?.currentTime = duration.seconds - 1
-        XCTAssert(audioPlayer.isPlaying == true, "Playing an audio should change the isPlaying to true")
-        XCTAssert(audioPlayer.player != nil, "Playing an audio should create the player instance")
         let expectation = self.expectation(description: "3 seconds")
+        
         DispatchQueue.global().asyncAfter(deadline: .now() + 3.0) { [self] in
             XCTAssert(audioPlayer.isPlaying == false, "isPlaying should set to false when audio reach the end")
             expectation.fulfill()


### PR DESCRIPTION
[TL-29]When set the playlist to an empty array, the audio player should not start to play, and the isPlaying should not be set to true.